### PR TITLE
There's no reason we shouldn't be able to run on ubuntu-latest

### DIFF
--- a/.github/workflows/TriggerDevOpsBuild.yml
+++ b/.github/workflows/TriggerDevOpsBuild.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: 'Trigger Staging'
       uses: Azure/pipelines@releases/v1


### PR DESCRIPTION
The Ubuntu-18.04 environment is deprecated and will be removed on April 1st, 2023. For more details, see https://github.com/actions/runner-images/issues/6002

![image](https://user-images.githubusercontent.com/5680199/228286020-aaf0a922-5cff-45f1-8b1b-5c9a61117aac.png)
