### PR TITLE
Griffen-Edge - Add hr after last badge

### DIFF
--- a/Griffen-Edge/Griffen-Edge.md
+++ b/Griffen-Edge/Griffen-Edge.md
@@ -25,6 +25,8 @@ quoteAuthor: "Don Norman"
 [[imgBadge]]
 | ![Adobe Illustrator](../badges/Designer-adobe-illustrator.png)
 
+---
+
 Griffen is a thoughtful and creative UI/UX Designer who thrives on solving complex design challenges with elegant, user-centered solutions. He brings a strong foundation in design thinking and accessibility, and is passionate about crafting experiences that are inclusive, intuitive, and visually engaging.
 
 At SSW, Griffen works closely with developers, consultants, and clients to deliver high-quality interfaces that balance form and function. His approach is collaborative and iterative, always grounded in user research and guided by empathy.


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Read the following
> Note: Add an `<hr />` using Markdown (---) after the last badge your have. This will generate a nice separator between badges and content.

from https://github.com/SSWConsulting/SSW.People.Profiles/wiki/6.-Extras-%E2%80%90-Editing-profiles

> 2. What was changed?

Added an `<hr />` using Markdown (---) after the last badge.