### PR TITLE
Reduce bold formatting in Hark Singh profile

### DIFF
--- a/Hark-Singh/Hark-Singh.md
+++ b/Hark-Singh/Hark-Singh.md
@@ -7,30 +7,30 @@ quote: "We are what we repeatedly do. Excellence, then, is not an act, but a hab
 quoteAuthor: "Aristotle"
 ---
 
-**Hark** is a passionate **Full-Stack Developer**, who builds **clean**, **reliable software** with a focus on **user experience** and **delivery discipline**.
+Hark is a passionate **Full-Stack Developer**, who builds clean, reliable software with a focus on user experience and delivery discipline.
 
-He joined **SSW Newcastle** through **FireBootCamp**, SSW's intensive, real-world training program for elite graduates, where he worked in a **high-pressure, consultancy-style environment**, building **production-grade solutions** using **Angular**, **.NET**, **Clean Architecture**, and **Azure DevOps**. After impressing the mentors and senior architects, he was invited to join **SSW full-time**.
+He joined SSW Newcastle through **FireBootCamp**, SSW's intensive, real-world training program for elite graduates, where he worked in a high-pressure, consultancy-style environment, building production-grade solutions using Angular, .NET, Clean Architecture, and Azure DevOps. After impressing the mentors and senior architects, he was invited to join SSW full-time.
 
-Since then, Hark has been applying those same standards on all projects: **shipping features quickly**, **taking feedback well**, and **communicating clearly with stakeholders**. Everyone finds him easy to work with. He's **calm**, **friendly**, and explains **technical decisions in plain English**.
+Since then, Hark has been applying those same standards on all projects: shipping features quickly, taking feedback well, and communicating clearly with stakeholders. Everyone finds him easy to work with. He's calm, friendly, and explains technical decisions in plain English.
 
 
 ## Technical Expertise
 * **Flutter** - Primary focus; passionate about crafting beautiful, performant mobile apps.  
-* **Backend-as-a-Service (BaaS) Platforms** - Proficient in **Firebase** and **Supabase**, leveraging them for authentication, storage, and real-time data handling.  
+* **Backend-as-a-Service (BaaS) Platforms** - Proficient in Firebase and Supabase, leveraging them for authentication, storage, and real-time data handling.  
 * **Web Development**  
-  * **Angular** for front-end development  
-  * **.NET (C#)** for backend APIs using **Clean Architecture** principles  
-* **Testing & Automation** - Experienced with **Playwright** for end-to-end testing and browser automation.  
-* **DevOps & CI/CD** - Experienced with **GitHub Actions**, **Azure DevOps**, and continuous integration and deployment workflows.  
-* **Web3 & Blockchain** - Explored **Solidity**, **Ethereum**, and **Polygon** chains, and successfully deployed his own **NFT collection**.  
-* **App Store Experience** - Experienced in publishing apps on both the **Apple App Store** and **Google Play Store**.  
+  * Angular for front-end development  
+  * .NET (C#) for backend APIs using Clean Architecture principles  
+* **Testing & Automation** - Experienced with Playwright for end-to-end testing and browser automation.  
+* **DevOps & CI/CD** - Experienced with GitHub Actions, Azure DevOps, and continuous integration and deployment workflows.  
+* **Web3 & Blockchain** - Explored Solidity, Ethereum, and Polygon chains, and successfully deployed his own NFT collection.  
+* **App Store Experience** - Experienced in publishing apps on both the Apple App Store and Google Play Store.  
 
 ## Beyond Tech
 * **[Tales of Hark - YouTube Channel](https://www.youtube.com/@talesofhark)** for sharing different aspects of Hark's life, including technical tutorials and personal stories.  
-* **Musical Hark** - Plays **tabla** at the Sikh temple.  
+* **Musical Hark** - Plays tabla at the Sikh temple.  
 * **Talkative** - Loves to talk and can chat on random topics for hours (a good listener too!).
 
-> Hark is always eager to learn, collaborate, and improve — and he welcomes open feedback to help him grow.
+> Hark is always eager to learn, collaborate, and improve - and he welcomes open feedback to help him grow.
 
 
 `youtube: https://www.youtube.com/embed/EUhQ1J-69KY`


### PR DESCRIPTION
The intro paragraphs had 15 bold runs across 67 words, so 39% of the words rendered bold. This drowned out the sentences on the People profile page and on the new Events page, which pulls the first two paragraphs from this file via the generated profile.md.

- Prose is plain text now, apart from "Full-Stack Developer" and "FireBootCamp"
- List items keep bold on the leading label only, matching the convention used elsewhere in this repo
- Video captions keep bold, per the SSW caption style
- Replaced an em dash with a plain dash

Wording is unchanged. Only the emphasis markers moved.

Fixes SSWConsulting/SSW.People#859

<img width="1730" height="1136" alt="image" src="https://github.com/user-attachments/assets/544400aa-b323-4c1f-97ea-178c7d8ee7e1" />

**Figure: Before vs after or Hark's profile text**

<!-- 
Check out the relevant rules
- https://www.ssw.com.au/rules/use-pull-request-templates-to-communicate-expectations/
- https://www.ssw.com.au/rules/rules-to-better-pull-requests
- https://www.ssw.com.au/rules/write-a-good-pull-request
- https://www.ssw.com.au/rules/over-the-shoulder-prs 
- https://www.ssw.com.au/rules/do-you-use-co-creation-patterns
-->
