### PR TITLE
Link Adam Cogan's speaker profile PDF

### DIFF
--- a/Adam-Cogan/Adam-Cogan.md
+++ b/Adam-Cogan/Adam-Cogan.md
@@ -66,6 +66,8 @@ His favourite Microsoft teams that he loves to work with are Nat Friedman’s Gi
 [[imgMd]]
 | ![Adam has spoken at user groups/conferences in these countries](./Images/Bio/figureMap.jpg)
 
+For a snapshot of Adam's signature topics, keynotes, and event history, see his [Speaker Profile (PDF)](https://www.ssw.com.au/downloads/Adam-Cogan-Speaker-Profile.pdf).
+
 ## Software Architecture
 
 Adam enjoys working with teams, improving their usage of Scrum and DevOps, reviewing the architecture of large .NET and Azure projects, while also taking an active interest in the overall User Experience (UX). He is also the founder and a mentor of SSW’s [FireBootCamp](https://firebootcamp.com/), an intensive 12-week .NET training course where developers are retrained, learning development and architecture best practices.


### PR DESCRIPTION
> 1. What triggered this change? (PBI link, Email Subject, conversation + reason, etc)

Adam's one-page speaker profile needed to be hosted and linked from his people profile.

> 2. What was changed?

Added a link to the **Speaking** section of `Adam-Cogan/Adam-Cogan.md`, pointing at the PDF now hosted on the main website:

`For a snapshot of Adam's signature topics, keynotes, and event history, see his [Speaker Profile (PDF)](https://www.ssw.com.au/downloads/Adam-Cogan-Speaker-Profile.pdf).`

⚠️ The PDF is added by SSWConsulting/SSW.Website#5028 — that needs to merge and deploy before this link resolves.

> 3. I paired or mob programmed with:

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)